### PR TITLE
Ensure lockdir and rundir exist with correct permissions on startup

### DIFF
--- a/etc/condor.init
+++ b/etc/condor.init
@@ -42,6 +42,13 @@ pidfile=/var/run/condor-cron/$prog.pid
 
 start() {
     echo -n $"Starting Condor-cron daemons: "
+
+    # Ensure the condor-cron rundir and lockdir exist
+    local rundir=$(condor_cron_config_val RUN)
+    local lockdir=$(condor_cron_config_val LOCK)
+    mkdir -p ${rundir} ${lockdir}
+    chown cndrcron:cndrcron ${rundir} ${lockdir}
+
     daemon --pidfile $pidfile --check $prog $prog -pidfile $pidfile
     RETVAL=$?
     echo


### PR DESCRIPTION
If /var/run or /var/lock happen to be on tmpfs filesystems, then the subdirectories
needed at runtime for condor-cron do not exist.  This commit adds code to the start()
function in /etc/rc.d/init.d/condor-cron to ensure the RUN and LOCK directories
are created and assigned the correct ownership.

Bug: https://ticket.grid.iu.edu/30906
