### PR TITLE
Need host-based security at least for HTCondor 8.9+

### DIFF
--- a/etc/condor_config
+++ b/etc/condor_config
@@ -71,7 +71,7 @@ EMAIL_DOMAIN = $(FULL_HOSTNAME)
 # Disable mail on service restart
 SCHEDD_RESTART_REPORT=
 
-ALLOW_READ = *
+use SECURITY : HOST_BASED
 
 #SEC_PASSWORD_FILE = $(LOCAL_DIR)/lib/condor-cron/pool_password
 #SEC_DAEMON_AUTHENTICATION = REQUIRED


### PR DESCRIPTION
Just setting `ALLOW_READ = *` is insufficient for HTCondor 8.9+. Selecting HOST_BASED security works.